### PR TITLE
fix: 앱 이름 변경

### DIFF
--- a/RandomMusic/RandomMusic/Info.plist
+++ b/RandomMusic/RandomMusic/Info.plist
@@ -29,5 +29,7 @@
 	<array>
 		<string>audio</string>
 	</array>
+    <key>CFBundleDisplayName</key>
+    <string>1PodShuffle</string>
 </dict>
 </plist>


### PR DESCRIPTION
- RandomMusic -> 1PodShuffle
- 프로젝트 이름 자체를 변경하는 건 파급이 어디까지 미칠 지 몰라 홈화면에서 표시되는 앱 이름만 변경